### PR TITLE
Fixed there are the same enty name bug

### DIFF
--- a/Helper/Post.class.php
+++ b/Helper/Post.class.php
@@ -48,7 +48,7 @@ class Post {
             $this->format = 'FILE_OBJECTS';
         }
 
-        if (isset($_POST[$entry])) {
+        else if (isset($_POST[$entry])) {
             $this->values = to_array($_POST[$entry]);
             if (is_encoded_file($this->values[0])) {
                 $this->format = 'BASE64_ENCODED_FILE_OBJECTS';


### PR DESCRIPTION
If there are the same entry name with file input's name, upload data in file input will be ignored.