### PR TITLE
Fix calculation of last successfully received patch

### DIFF
--- a/index.php
+++ b/index.php
@@ -72,8 +72,12 @@ function handle_patch_file_transfer($id) {
             list($dir, $offset) = explode('.patch.', $filename, 2);
 
             // offsets
-            array_push($offsets, $offset);
+            array_push($offsets, intval($offset));
+        }
 
+        sort($offsets);
+
+        foreach ($offsets as $offset) {
             // test if is missing previous chunk
             // don't test first chunk (previous chunk is non existent)
             if ($offset > 0 && !in_array($offset - $size, $offsets)) {


### PR DESCRIPTION
When a file transfer is resumed, as a first step a HEAD request to the patch endpoint is made to determine where to resume.
In the previous implementetation the offset was not calculated in the right way. That way the resume offset was lower than necessary.

The problem was, that the glob result is sorted lexicographically. As a consequence some offsets were determined as not present, because the previous one comes in a later iteration.

Here is a small example:
glob result (folder path stripped): `[.patch.0,.patch.10000000,.patch.15000000,.patch.5000000]`

Before change:
`$last_offset` after loop: `5000000` (loop breaks in second iteration)
`$offsets` after loop: `[0,10000000]`

After change:
`$offsets` after sort: `[0,5000000,10000000,15000000]`
`$last_offset` at the end: `20000000`